### PR TITLE
Join geo accuracy

### DIFF
--- a/distil_primitives_contrib/fuzzy_join.py
+++ b/distil_primitives_contrib/fuzzy_join.py
@@ -5,10 +5,13 @@ import collections
 import pandas as pd  # type: ignore
 import numpy as np
 
+import haversine as hs
+
 from d3m import container, exceptions, utils as d3m_utils
 from d3m.base import utils as d3m_base_utils
 from d3m.metadata import base as metadata_base, hyperparams
 from d3m.primitive_interfaces import base, transformer
+from haversine import Unit
 from fuzzywuzzy import process
 from dateutil import parser
 import version
@@ -147,12 +150,17 @@ class FuzzyJoinPrimitive(
         ("https://metadata.datadrivendiscovery.org/types/FloatVector",)
     )
 
+    _GEO_JOIN_TYPES = set(
+        ("https://metadata.datadrivendiscovery.org/types/BoundingPolygon",)
+    )
+
     _DATETIME_JOIN_TYPES = set(("http://schema.org/DateTime",))
 
     _SUPPORTED_TYPES = (
         _STRING_JOIN_TYPES.union(_NUMERIC_JOIN_TYPES)
         .union(_DATETIME_JOIN_TYPES)
         .union(_VECTOR_JOIN_TYPES)
+        .union(_GEO_JOIN_TYPES)
     )
 
     __author__ = ("Uncharted Software",)
@@ -310,6 +318,21 @@ class FuzzyJoinPrimitive(
                 new_right_cols.append(right_name)
             elif join_types[col_index] in self._VECTOR_JOIN_TYPES:
                 new_left_df, new_right_df = self._create_vector_merging_cols(
+                    left_df,
+                    left_col[col_index],
+                    right_df,
+                    right_col[col_index],
+                    accuracy[col_index],
+                    col_index,
+                    absolute_accuracy[col_index],
+                )
+                left_df[new_left_df.columns] = new_left_df
+                right_df[new_right_df.columns] = new_right_df
+                new_left_cols += list(new_left_df.columns)
+                new_right_cols += list(new_right_df.columns)
+                right_cols_to_drop.append(right_col[col_index])
+            elif join_types[col_index] in self._VECTOR_JOIN_TYPES:
+                new_left_df, new_right_df = self._create_geo_vector_merging_cols(
                     left_df,
                     left_col[col_index],
                     right_df,
@@ -542,6 +565,22 @@ class FuzzyJoinPrimitive(
             distance = abs(match - num)
             if distance <= tolerance and distance <= min_distance:
                 min_val = num
+                min_distance = distance
+        return min_val
+
+    def _geo_fuzzy_match(match, choices, accuracy, is_absolute):
+        # assume the accuracy is meters
+        if not is_absolute:
+            raise exceptions.InvalidArgumentTypeError(
+                "geo fuzzy match requires an absolute accuracy parameter that specifies the tolerance in meters"
+            )
+        min_distance = float("inf")
+        min_val = None
+        for i, point in enumerate(choices):
+            distance = abs(hs.haversine(match, point, Unit.METERS))
+            if distance <= accuracy and distance <= min_distance:
+                min_val = point
+                min_distance = distance
         return min_val
 
     @classmethod
@@ -567,6 +606,86 @@ class FuzzyJoinPrimitive(
             }
         )
         return new_left_df
+
+    @classmethod
+    def _create_geo_vector_merging_cols(
+        cls,
+        left_df: container.DataFrame,
+        left_col: str,
+        right_df: container.DataFrame,
+        right_col: str,
+        accuracy: float,
+        index: int,
+        is_absolute: bool,
+    ) -> pd.DataFrame:
+        def fromstring(x: str) -> np.ndarray:
+            return np.fromstring(x, dtype=float, sep=",")
+        def topoints(x: np.ndarray) -> typing.Sequence[typing.Sequence[float]]:
+            # create a sequence of points by joining two successive values
+            it = iter(x)
+            return list(zip(it, it))
+
+        if type(left_df[left_col][0]) == str:
+            left_vector_length = np.fromstring(
+                left_df[left_col][0], dtype=float, sep=","
+            ).shape[0]
+            new_left_cols = [
+                "lefty_vector" + str(index) + "_" + str(i)
+                for i in range(left_vector_length/2)
+            ]
+            new_left_df = container.DataFrame(
+                left_df[left_col]
+                .apply(fromstring, convert_dtype=False)
+                .apply(topoints)
+                .values.tolist(),
+                columns=new_left_cols,
+            )
+        else:
+            left_vector_length = left_df[left_col][0].shape[0]
+            new_left_cols = [
+                "lefty_vector" + str(index) + "_" + str(i)
+                for i in range(left_vector_length/2)
+            ]
+            new_left_df = container.DataFrame(
+                left_df[left_col].apply(topoints).values.tolist(),
+                columns=new_left_cols,
+            )
+        if type(right_df[right_col][0]) == str:
+            right_vector_length = np.fromstring(
+                right_df[right_col][0], dtype=float, sep=","
+            ).shape[0]
+            new_right_cols = [
+                "righty_vector" + str(index) + "_" + str(i)
+                for i in range(right_vector_length/2)
+            ]
+            new_right_df = container.DataFrame(
+                right_df[right_col]
+                .apply(fromstring, convert_dtype=False)
+                .apply(topoints)
+                .values.tolist(),
+                columns=new_right_cols,
+            )
+        else:
+            right_vector_length = right_df[right_col][0].shape[0]
+            new_right_cols = [
+                "righty_vector" + str(index) + "_" + str(i)
+                for i in range(right_vector_length/2)
+            ]
+            new_right_df = container.DataFrame(
+                right_df[right_col].apply(topoints).values.tolist(),
+                columns=new_right_cols,
+            )
+
+        for i in range(len(new_left_cols)):
+            new_left_df[new_left_cols[i]] = new_left_df[new_left_cols[i]].map(
+                lambda x: cls._geo_fuzzy_match(
+                    x,
+                    new_right_df[new_right_cols[i]],
+                    accuracy,
+                    is_absolute,
+                )
+            )
+        return (new_left_df, new_right_df)
 
     @classmethod
     def _create_vector_merging_cols(

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "joblib>=0.13.2",
         "fuzzywuzzy>=0.17.0",
         "python-Levenshtein>=0.12.0",
+        "haversine==2.3.1"
     ],
     entry_points={
         "d3m.primitives": [

--- a/test/test_fuzzy_join.py
+++ b/test/test_fuzzy_join.py
@@ -152,6 +152,7 @@ class FuzzyJoinPrimitiveTestCase(unittest.TestCase):
                 "left_col": "whiskey",
                 "right_col": "xray",
                 "accuracy": 0.9,
+                "absolute_accuracy": False,
             }
         )
         fuzzy_join = FuzzyJoin(hyperparams=hyperparams)
@@ -272,6 +273,115 @@ class FuzzyJoinPrimitiveTestCase(unittest.TestCase):
             self.assertNumpyListEqual(
                 list(result_dataframe["charlie"]),
                 [200.0, 200.0, 200.0, 200.0, np.nan, np.nan, np.nan, np.nan],
+            )
+        )
+
+    def test_geo_join(self) -> None:
+        dataframe_1 = self._load_data(self._dataset_path_1)
+        dataframe_2 = self._load_data(self._dataset_path_2)
+        dataframe_1.metadata = dataframe_1.metadata.add_semantic_type(
+            ('0', metadata_base.ALL_ELEMENTS, 5),
+            "https://metadata.datadrivendiscovery.org/types/BoundingPolygon",
+        )
+        dataframe_2.metadata = dataframe_2.metadata.add_semantic_type(
+            ('0', metadata_base.ALL_ELEMENTS, 5),
+            "https://metadata.datadrivendiscovery.org/types/BoundingPolygon",
+        )
+
+        hyperparams_class = FuzzyJoin.metadata.query()["primitive_code"][
+            "class_type_arguments"
+        ]["Hyperparams"]
+        hyperparams = hyperparams_class.defaults().replace(
+            {
+                "left_col": "gamma",
+                "right_col": "gamma",
+                "accuracy": 15600,
+                "absolute_accuracy": True
+            }
+        )
+        fuzzy_join = FuzzyJoin(hyperparams=hyperparams)
+        result_dataset = fuzzy_join.produce(left=dataframe_1, right=dataframe_2).value
+        result_dataframe = result_dataset["0"]
+        self.assertListEqual(
+            list(result_dataframe.columns),
+            [
+                "d3mIndex",
+                "alpha_left",
+                "bravo",
+                "whiskey",
+                "sierra",
+                "gamma",
+                "alpha_right",
+                "charlie",
+                "xray",
+                "tango",
+            ],
+        )
+        self.assertListEqual(
+            list(result_dataframe["d3mIndex"]),
+            [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+            ],
+        )
+        self.assertListEqual(
+            list(result_dataframe["alpha_left"]),
+            [
+                "yankee",
+                "yankeee",
+                "yank",
+                "Hotel",
+                "hotel",
+                "otel",
+                "foxtrot aa",
+                "foxtrot",
+            ],
+        )
+        self.assertListEqual(
+            list(result_dataframe["bravo"]),
+            [
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                5.0,
+                6.0,
+                7.0,
+                8.0,
+            ],
+        )
+        self.assertListEqual(
+            [row.tolist() for row in result_dataframe["gamma"]],
+            [
+                [10.0, 20.0],
+                [5.0, 3.0],
+                [30.0, 52.0],
+                [5.0, 3.0],
+                [10.0, 20.0],
+                [13.0, 13.0],
+                [13.0, 13.0],
+                [3.0, 5.0],
+            ],
+        )
+        self.assertTrue(
+            self.assertNumpyListEqual(
+                list(result_dataframe["alpha_right"]),
+                [
+                    "yankee",
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                    "yankee",
+                    "foxtrot",
+                    "foxtrot",
+                    "golf",
+                ],
             )
         )
 
@@ -448,6 +558,7 @@ class FuzzyJoinPrimitiveTestCase(unittest.TestCase):
                 "left_col": ["alpha", "sierra"],
                 "right_col": ["alpha", "tango"],
                 "accuracy": [0.9, 0.8],
+                "absolute_accuracy": [False, False],
             }
         )
         fuzzy_join = FuzzyJoin(hyperparams=hyperparams)
@@ -508,6 +619,7 @@ class FuzzyJoinPrimitiveTestCase(unittest.TestCase):
                 "left_col": ["sierra", "gamma"],
                 "right_col": ["tango", "gamma"],
                 "accuracy": [0.8, 0.95],
+                "absolute_accuracy": [False, False],
             }
         )
         fuzzy_join = FuzzyJoin(hyperparams=hyperparams)


### PR DESCRIPTION
Adds support for geo joining based on the bounding polygon semantic type, which assumes that a field flagged with that is a flat vector of (x,y) points and uses haversine distance to estimate the distance between points when joining to allow for some fuzziness.

Fixed how the join type was determined to allow for multiple join type function to return all allowed join types. The order of precedence is determined by the calling code now.

Fixed broken tests (due to absolute accuracy being a list now) and added geo join test.